### PR TITLE
Add refactoring plan

### DIFF
--- a/refactor_plan/README.md
+++ b/refactor_plan/README.md
@@ -1,0 +1,18 @@
+# Refactoring Plan
+
+This project currently stores nearly all utilities in **FinancialMachineLearning.py**. To make the library easier to maintain we will divide the functions into focused modules.
+
+## Proposed File Structure
+
+- `data_preparation.py` – routines to load and clean raw market data.
+- `bar_sampling.py` – tick, volume and dollar bar generation utilities.
+- `labeling.py` – event extraction, barrier placement and label creation.
+- `fractional_diff.py` – fractional differencing and related utilities.
+- `cross_validation.py` – PurgedKFold and CV scoring helpers.
+- `feature_importance.py` – MDI/MDA/SFI feature importance implementations.
+- `hyperparameter.py` – grid search and random search helpers.
+- `bet_sizing.py` – bet size calculation and position management utilities.
+- `plotting.py` – functions for visualizing bars, weights and statistics.
+- `multiprocessing_utils.py` – generic multiprocessing helpers (mpPandasObj, mpJobList etc.).
+
+Each notebook will import from these modules to keep code modular and manageable.


### PR DESCRIPTION
## Summary
- plan for splitting `FinancialMachineLearning.py` into separate modules

## Testing
- `python -m py_compile FinancialMachineLearning.py`

------
https://chatgpt.com/codex/tasks/task_e_6849b63053bc832e815a02932b4cf8cf