### PR TITLE
Add pipeline visualization web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,8 @@ cv_gen = KFold(n_splits = 10, shuffle = False)
 score = fml.cvScore(rf, X, y, sample_weight = cweight, scoring = 'neg_log_loss', cv = None, cvGen = cv_gen, pctEmbargo = 0)
 ```
 단, 여기서 사용되는 sample_weight는 행렬 X,y와 길이가 같아야 합니다. 또한, pandas version은 1.5.3으로 맞춰야 합니다
+
+
+## Pipeline Viewer
+An optional web interface for visualizing the function pipeline is provided in `pipeline_viewer/`.
+Run `python -m pipeline_viewer.app` and open `http://localhost:5000`. Click **Refresh** to update the graph.

--- a/pipeline_viewer/README.md
+++ b/pipeline_viewer/README.md
@@ -1,0 +1,14 @@
+# Pipeline Viewer
+
+This folder contains a simple Flask web application that visualizes the
+function call pipeline of the modules inside `refactor_plan`.
+
+Run the app with:
+
+```bash
+python -m pipeline_viewer.app
+```
+
+Open `http://localhost:5000` in your browser to see the graph.
+Click the **Refresh** link to update the pipeline after modifying code
+under `refactor_plan`.

--- a/pipeline_viewer/__init__.py
+++ b/pipeline_viewer/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/pipeline_viewer/app.py
+++ b/pipeline_viewer/app.py
@@ -1,0 +1,31 @@
+from flask import Flask, redirect, url_for
+import os
+from .graph_builder import build_pipeline_graph
+
+app = Flask(__name__, static_folder='static')
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+REF_PLAN_DIR = os.path.join(BASE_DIR, 'refactor_plan')
+OUTPUT_HTML = os.path.join(app.static_folder, 'pipeline.html')
+
+
+def generate_graph():
+    build_pipeline_graph(REF_PLAN_DIR, OUTPUT_HTML)
+
+
+@app.route('/')
+def index():
+    if not os.path.exists(OUTPUT_HTML):
+        generate_graph()
+    with open(OUTPUT_HTML, 'r', encoding='utf-8') as f:
+        return f.read()
+
+
+@app.route('/refresh')
+def refresh():
+    generate_graph()
+    return redirect(url_for('index'))
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/pipeline_viewer/graph_builder.py
+++ b/pipeline_viewer/graph_builder.py
@@ -1,0 +1,17 @@
+import networkx as nx
+from pyvis.network import Network
+from .parser import parse_functions
+import os
+
+
+def build_pipeline_graph(source_dir: str, output_html: str) -> None:
+    calls = parse_functions(source_dir)
+    G = nx.DiGraph()
+    for func, called_set in calls.items():
+        G.add_node(func)
+        for callee in called_set:
+            G.add_edge(func, callee)
+    net = Network(directed=True, height='750px', width='100%')
+    net.from_nx(G)
+    os.makedirs(os.path.dirname(output_html), exist_ok=True)
+    net.write_html(output_html)

--- a/pipeline_viewer/parser.py
+++ b/pipeline_viewer/parser.py
@@ -1,0 +1,59 @@
+import os
+import ast
+from typing import Dict, Set
+
+
+def _collect_functions(tree: ast.AST) -> Set[str]:
+    funcs = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            funcs.add(node.name)
+    return funcs
+
+
+def parse_functions(directory: str) -> Dict[str, Set[str]]:
+    """Parse functions and their calls inside a directory."""
+    modules = {}
+    for fname in os.listdir(directory):
+        if fname.endswith('.py'):
+            path = os.path.join(directory, fname)
+            module = os.path.splitext(fname)[0]
+            with open(path, 'r', encoding='utf-8') as f:
+                tree = ast.parse(f.read())
+            funcs = _collect_functions(tree)
+            for fn in funcs:
+                modules[f"{module}.{fn}"] = set()
+
+    # second pass to collect calls
+    for fname in os.listdir(directory):
+        if fname.endswith('.py'):
+            path = os.path.join(directory, fname)
+            module = os.path.splitext(fname)[0]
+            with open(path, 'r', encoding='utf-8') as f:
+                tree = ast.parse(f.read())
+            for node in ast.walk(tree):
+                if isinstance(node, ast.FunctionDef):
+                    caller = f"{module}.{node.name}"
+                    called = _find_called_functions(node.body, modules.keys())
+                    modules[caller].update(called)
+    return modules
+
+
+def _find_called_functions(nodes, valid: Set[str]) -> Set[str]:
+    calls = set()
+    for node in ast.walk(ast.Module(body=nodes)):
+        if isinstance(node, ast.Call):
+            name = None
+            if isinstance(node.func, ast.Name):
+                name = node.func.id
+            elif isinstance(node.func, ast.Attribute):
+                attr = node.func.attr
+                if isinstance(node.func.value, ast.Name):
+                    name = f"{node.func.value.id}.{attr}"
+                else:
+                    name = attr
+            if name:
+                for func in valid:
+                    if func == name or func.endswith(f".{name}"):
+                        calls.add(func)
+    return calls


### PR DESCRIPTION
## Summary
- create `pipeline_viewer` Flask app to show function call pipeline
- generate network graph automatically from modules in `refactor_plan`
- document how to run the viewer in both README files

## Testing
- `python -m py_compile pipeline_viewer/*.py`
- `python -m pipeline_viewer.app` *(ran briefly to ensure it starts)*

------
https://chatgpt.com/codex/tasks/task_e_684b0588837c832ea1261f104010beb3