### PR TITLE
Implement missing notebook utilities

### DIFF
--- a/refactor_plan/bet_sizing.py
+++ b/refactor_plan/bet_sizing.py
@@ -60,6 +60,9 @@ import copyreg, types, multiprocessing as mp
 import copy
 import platform
 from multiprocessing import cpu_count
+from dataclasses import dataclass
+from typing import Optional
+import brownian_motion
 
 from numba import jit
 from tqdm import tqdm, tqdm_notebook
@@ -81,6 +84,7 @@ from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
 from sklearn.pipeline import Pipeline
 from sklearn.model_selection._split import _BaseKFold
 from sklearn import metrics
+from sklearn.linear_model import LinearRegression
 
 def avgActiveSignals_(signals: pd.DataFrame, molecule: np.ndarray):
     '''
@@ -373,4 +377,164 @@ def processBatch(coeffs_list, **kwargs):
         out.append((coeffs, Batch(coeffs, **kwargs)))
     return out
 
-__all__ = ['avgActiveSignals_','avgActiveSignals','discrete_signal','get_signal','betSize','getTargetPos','invPrice','limitPrice','getW','getNumConcBets','getBetsTiming','getHoldingPeriod','getHHI','computeDD_TuW','Batch','processBatch']
+# ======================================================================
+# Additions from missing functions list
+# ======================================================================
+
+def expected_max(N: int) -> float:
+    """Return expected maximum of ``N`` standard normal draws."""
+    if N < 5:
+        raise AssertionError("Condition N >> 1 not satisfied.")
+    return (
+        (1 - np.euler_gamma) * stats.norm.ppf(1 - 1.0 / N)
+        + np.euler_gamma * stats.norm.ppf(1 - np.exp(-1) / N)
+    )
+
+
+def PSR(sharpe: float, T: int, skew: float, kurtosis: float, target_sharpe: float = 0) -> float:
+    """Probabilistic Sharpe Ratio adjusting for skew and kurtosis."""
+    value = (
+        (sharpe - target_sharpe)
+        * np.sqrt(T - 1)
+        / np.sqrt(1.0 - skew * sharpe + sharpe ** 2 * (kurtosis - 1) / 4.0)
+    )
+    return stats.norm.cdf(value, 0, 1)
+
+
+def DSR(test_sharpe: float, sharpe_std: float, N: int, T: int, skew: float, kurtosis: float) -> float:
+    """Compute Deflated Sharpe Ratio for given performance series."""
+    target_sharpe = sharpe_std * expected_max(N)
+    return PSR(test_sharpe, T, skew, kurtosis, target_sharpe)
+
+
+def betSizePower(x: float, w: float) -> float:
+    """Power-transformed bet size used as an alternative to ``betSize``."""
+    return np.sign(w) * abs(w) ** x
+
+
+def binSR(sl: float, pt: float, freq: float, p: float) -> float:
+    """Theoretical annualized Sharpe ratio under a Bernoulli trading model."""
+    mean = p * pt - (1 - p) * sl
+    var = p * pt ** 2 + (1 - p) * sl ** 2 - mean ** 2
+    return np.sqrt(freq) * mean / np.sqrt(var)
+
+
+def binHR(sl: float, pt: float, freq: float, tSR: float) -> float:
+    """Solve for hit rate ``p`` that achieves target Sharpe ratio ``tSR``."""
+    a = (freq + tSR ** 2) * (pt - sl) ** 2
+    b = (2 * freq * sl - tSR ** 2 * (pt - sl)) * (pt - sl)
+    c = freq * sl ** 2
+    return (-b + np.sqrt(b ** 2 - 4 * a * c)) / (2.0 * a)
+
+
+def binFreq(sl: float, pt: float, p: float, tSR: float) -> Optional[float]:
+    """Frequency needed to reach a target Sharpe ratio."""
+    freq = (tSR * (pt - sl)) ** 2 * p * (1 - p) / ((pt - sl) * p + sl) ** 2
+    if not np.isclose(binSR(sl, pt, freq, p), tSR):
+        return None
+    return freq
+
+
+def mixGaussians(mu1, mu2, sigma1, sigma2, prob1, nObs):
+    """Sample ``nObs`` observations from a two-component Gaussian mixture."""
+    ret1 = np.random.normal(mu1, sigma1, size=int(nObs * prob1))
+    ret2 = np.random.normal(mu2, sigma2, size=int(nObs) - ret1.shape[0])
+    ret = np.append(ret1, ret2, axis=0)
+    np.random.shuffle(ret)
+    return ret
+
+
+def probFailure(ret: np.ndarray, freq: float, tSR: float) -> float:
+    """Probability that the Sharpe ratio does not exceed ``tSR``."""
+    rPos, rNeg = ret[ret > 0].mean(), ret[ret <= 0].mean()
+    p = ret[ret > 0].shape[0] / float(ret.shape[0])
+    thresP = binHR(rNeg, rPos, freq, tSR)
+    return stats.norm.cdf(thresP, p, p * (1 - p))
+
+
+def runSRtrials(p: float, pt: float = 1, sl: float = 1, trials: int = 100000) -> float:
+    """Monte Carlo estimate of the Sharpe ratio for a Bernoulli strategy."""
+    out = []
+    for _ in range(trials):
+        rnd = np.random.binomial(n=1, p=p)
+        out.append(pt if rnd == 1 else -sl)
+    return np.mean(out) / np.std(out)
+
+
+def jiggle(v: float):
+    """Return 1% variations around ``v``."""
+    return [v * 0.99, v, v * 1.01]
+
+
+def genHeatmap(forecast: float, hl: float, sigma: float = 1):
+    """Run OU simulations and return batch output for heatmap plotting."""
+    rPT = rSLm = np.linspace(0, 10, 21)
+    coeffs = {"forecast": forecast, "hl": hl, "sigma": sigma}
+    return Batch(coeffs, nIter=1e5, maxHP=100, rPT=rPT, rSLm=rSLm)
+
+
+def OUcoeff():
+    """Sweep OU parameters and run batch simulations."""
+    rPT = rSLm = np.linspace(0, 10, 21)
+    for prod_ in product([10, 5, 0, -5, -10], [5, 10, 25, 50, 100]):
+        coeffs = {"forecast": prod_[0], "hl": prod_[1], "sigma": 1}
+        output = Batch(coeffs, nIter=1e5, maxHP=100, rPT=rPT, rSLm=rSLm)
+    return output
+
+
+@dataclass
+class OUParams:
+    """Parameters of an Ornstein–Uhlenbeck process."""
+
+    phi: float
+    gamma: float
+    sigma: float
+
+
+def estimateOUParams(X_t: np.ndarray) -> OUParams:
+    """Estimate OU parameters via ordinary least squares."""
+    y = np.diff(X_t)
+    X = X_t[:-1].reshape(-1, 1)
+    reg = LinearRegression(fit_intercept=True)
+    reg.fit(X, y)
+    phi = -reg.coef_[0]
+    gamma = reg.intercept_ / phi
+    y_hat = reg.predict(X)
+    sigma = np.std(y - y_hat)
+    return OUParams(phi, gamma, sigma)
+
+
+def getIntegalW(t: np.ndarray, dW: np.ndarray, OU_params: OUParams) -> np.ndarray:
+    r"""Compute ``\int e^{phi t} dW`` for the OU process."""
+    exp_phi_s = np.exp(OU_params.phi * t)
+    integral_W = np.cumsum(exp_phi_s * dW)
+    return np.insert(integral_W, 0, 0)[:-1]
+
+
+def selectX0(X_0_in: Optional[float], OU_params: OUParams) -> float:
+    """Choose initial value ``X_0``; defaults to long‑term mean."""
+    return X_0_in if X_0_in is not None else OU_params.gamma
+
+
+def getOUProcess(
+    T: int,
+    OU_params: OUParams,
+    X_0: Optional[float] = None,
+    random_state: Optional[int] = None,
+) -> np.ndarray:
+    """Generate a sample path of an Ornstein–Uhlenbeck process."""
+    t = np.arange(T, dtype=np.float128)
+    exp_alpha_t = np.exp(-OU_params.phi * t)
+    dW = brownian_motion.get_dW(T, random_state)
+    integral_W = getIntegalW(t, dW, OU_params)
+    _X_0 = selectX0(X_0, OU_params)
+    return _X_0 * exp_alpha_t + OU_params.gamma * (1 - exp_alpha_t) + OU_params.sigma * exp_alpha_t * integral_W
+
+__all__ = [
+    'avgActiveSignals_','avgActiveSignals','discrete_signal','get_signal','betSize',
+    'getTargetPos','invPrice','limitPrice','getW','getNumConcBets','getBetsTiming',
+    'getHoldingPeriod','getHHI','computeDD_TuW','Batch','processBatch',
+    'expected_max','PSR','DSR','betSizePower','binSR','binHR','binFreq',
+    'mixGaussians','probFailure','runSRtrials','jiggle','genHeatmap','OUcoeff',
+    'OUParams','estimateOUParams','getIntegalW','selectX0','getOUProcess'
+]

--- a/refactor_plan/cross_validation.py
+++ b/refactor_plan/cross_validation.py
@@ -250,4 +250,20 @@ def crossValPlot(skf,classifier,X_,y_):
     ax.set_title('Receiver operating characteristic example')
     ax.legend(bbox_to_anchor=(1,1))
 
-__all__ = ['PurgedKFold','cvScore','crossValPlot','getTrainTimes','getEmbargoTimes']
+# ======================================================================
+# Additions from missing functions list
+# ======================================================================
+
+def get_IS_sharpe_ratio(clf) -> float:
+    """Return in-sample Sharpe ratio from a CV estimator."""
+    best_est = np.argmin(clf.cv_results_['rank_test_score'])
+    mean_score = clf.cv_results_['mean_test_score'][best_est]
+    std_score = clf.cv_results_['std_test_score'][best_est]
+    if mean_score < 0:
+        return -mean_score / std_score
+    return mean_score / std_score
+
+__all__ = [
+    'PurgedKFold','cvScore','crossValPlot','getTrainTimes','getEmbargoTimes',
+    'get_IS_sharpe_ratio'
+]

--- a/refactor_plan/data_preparation.py
+++ b/refactor_plan/data_preparation.py
@@ -45,6 +45,7 @@ import scipy.stats as stats
 from scipy import interp
 from scipy.stats import rv_continuous, kstest, norm
 import scipy.cluster.hierarchy as sch
+import scipy.optimize
 
 import copyreg, types, multiprocessing as mp
 import copy
@@ -139,4 +140,46 @@ def madOutlier(y, thresh = 3.):
     print(modified_z_score)
     return modified_z_score > thresh
 
-__all__ = ['getDataFrame', 'numba_isclose', 'getOHLC', 'madOutlier']
+# ======================================================================
+# Additions from missing functions list
+# ======================================================================
+
+def partition_monthly(s: pd.Series) -> pd.Series:
+    """Return monthly variance of a time series."""
+    return s.resample('1M').var()
+
+
+def fit_sin(tt, yy):
+    """Fit a sinusoidal curve to data."""
+    tt = np.array(tt)
+    yy = np.array(yy)
+    ff = np.fft.fftfreq(len(tt), (tt[1] - tt[0]))
+    Fyy = abs(np.fft.fft(yy))
+    guess_freq = abs(ff[np.argmax(Fyy[1:]) + 1])
+    guess_amp = np.std(yy) * 2.0 ** 0.5
+    guess_offset = np.mean(yy)
+    guess = np.array([guess_amp, 2.0 * np.pi * guess_freq, 0.0, guess_offset])
+
+    def sinfunc(t, A, w, p, c):
+        return A * np.sin(w * t + p) + c
+
+    popt, pcov = scipy.optimize.curve_fit(sinfunc, tt, yy, p0=guess)
+    A, w, p, c = popt
+    f = w / (2.0 * np.pi)
+    fitfunc = lambda t: A * np.sin(w * t + p) + c
+    return {
+        'amp': A,
+        'omega': w,
+        'phase': p,
+        'offset': c,
+        'freq': f,
+        'period': 1.0 / f,
+        'fitfunc': fitfunc,
+        'maxcov': np.max(pcov),
+        'rawres': (guess, popt, pcov),
+    }
+
+__all__ = [
+    'getDataFrame', 'numba_isclose', 'getOHLC', 'madOutlier',
+    'partition_monthly', 'fit_sin'
+]

--- a/refactor_plan/labeling.py
+++ b/refactor_plan/labeling.py
@@ -683,4 +683,22 @@ def getTimeDecay(tW, clfLastW = 1.):
     const = 1. - slope * clfW.iloc[-1]
     clfW = const + slope * clfW
 
-__all__ = ['getDailyVolatility','addVerticalBarrier','tradableHour','getTEvents','getTripleBarrier','getEvents','getBins','dropLabels','getBinsNew','get_up_cross','get_down_cross','getUpCross','getDownCross','getConcurrentBar','getAvgLabelUniq','mpSampleWeights','getBollingerBand','getSampleWeights','getIndMatrix','getAvgUniqueness','seqBootstrap','getRndT1','auxMC','mainMC','mpSampleW','SampleW','getConcurUniqueness','getTimeDecay']
+    return clfW
+
+# ======================================================================
+# Additions from missing functions list
+# ======================================================================
+
+def getExTimeDecay(tW, clfLastW: float = 1.0, exponent: int = 1):
+    """Exponential time decay for event weights."""
+    clfW = tW.sort_index().cumsum()
+    if clfLastW >= 0:
+        slope = ((1.0 - clfLastW) / clfW.iloc[-1]) ** exponent
+    else:
+        slope = (1.0 / ((clfLastW + 1) * clfW.iloc[-1])) ** exponent
+    const = 1.0 - slope * clfW.iloc[-1]
+    clfW = const + slope * clfW
+    clfW[clfW < 0] = 0
+    return clfW
+
+__all__ = ['getDailyVolatility','addVerticalBarrier','tradableHour','getTEvents','getTripleBarrier','getEvents','getBins','dropLabels','getBinsNew','get_up_cross','get_down_cross','getUpCross','getDownCross','getConcurrentBar','getAvgLabelUniq','mpSampleWeights','getBollingerBand','getSampleWeights','getIndMatrix','getAvgUniqueness','seqBootstrap','getRndT1','auxMC','mainMC','mpSampleW','SampleW','getConcurUniqueness','getTimeDecay','getExTimeDecay']

--- a/refactor_plan/plotting.py
+++ b/refactor_plan/plotting.py
@@ -160,4 +160,19 @@ def plotFeatImportance(pathOut, imp, oob, oos, method, tag=0, simNum=0, **kargs)
     plt.close()
     return
 
-__all__ = ['plot_bar_counts','plot_hist','plotSampleData','plot_autocorr','plotWeights','plotMinFFD','plotFeatImportance','plotCorrMatrix']
+# ======================================================================
+# Additions from missing functions list
+# ======================================================================
+
+def OUHeatmap(coeffs, outputs):
+    """Return a seaborn heatmap for OU simulation results."""
+    heatdf = pd.DataFrame(outputs)
+    heatdfp = heatdf.pivot(1, 0, 4)
+    plt.subplots()
+    return sns.heatmap(heatdfp.sort_index(ascending=False))
+
+__all__ = [
+    'plot_bar_counts','plot_hist','plotSampleData','plot_autocorr',
+    'plotWeights','plotMinFFD','plotFeatImportance','plotCorrMatrix',
+    'OUHeatmap'
+]


### PR DESCRIPTION
## Summary
- bring over finance notebook helpers into refactor modules
- support OU simulations, Sharpe ratio statistics and signal utilities
- expose new plotting and data-prep helpers

## Testing
- `python -m py_compile refactor_plan/bet_sizing.py`
- `python -m py_compile refactor_plan/plotting.py`
- `python -m py_compile refactor_plan/labeling.py`
- `python -m py_compile refactor_plan/cross_validation.py`
- `python -m py_compile refactor_plan/data_preparation.py`


------
https://chatgpt.com/codex/tasks/task_e_684eb4a4f4a0832e87162e773e60ebc2